### PR TITLE
Revert "Update code.forgejo.org/forgejo-helm/forgejo Docker tag to v17"

### DIFF
--- a/starlight30/forgejo/fleet.yaml
+++ b/starlight30/forgejo/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: forgejo
 
 helm:
   chart: oci://code.forgejo.org/forgejo-helm/forgejo
-  version: 17.1.1
+  version: 14.0.4
   values:
     replicaCount: 1
 


### PR DESCRIPTION
Reverts pikatenor/infra#121

```
execution error at (forgejo/templates/gitea/admin-secret.yaml:12:15):
PASSWORDS ERROR: You must provide your current passwords when upgrading the release.
Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims.
Further information can be obtained at https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases

'gitea.admin.password' must not be empty, please add '--set gitea.admin.password=$PASSWORD' to the command. To get the current value:

export PASSWORD=$(kubectl get secret --namespace "forgejo" starlight30-starlight30-forgejo-admin -o jsonpath="{.data.password}" | base64 -d)
```