### PR TITLE
forgejo: disable chart-side admin user management (helm v15 compat)

### DIFF
--- a/starlight30/forgejo/fleet.yaml
+++ b/starlight30/forgejo/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: forgejo
 
 helm:
   chart: oci://code.forgejo.org/forgejo-helm/forgejo
-  version: 14.0.4
+  version: 17.1.1
   values:
     replicaCount: 1
 
@@ -28,8 +28,10 @@ helm:
           DISABLE_ORGANIZATIONS_PAGE: true
           DISABLE_CODE_PAGE: true
       admin:
-        username: pikatenor
-        passwordMode: initialOnlyRequireReset
+        # admin user is not managed by the chart: initial setup + password
+        # reset were done out-of-band. Empty username disables chart-side
+        # admin management (required since forgejo-helm v15).
+        username: ""
 
     service:
       ssh:


### PR DESCRIPTION
## Context

Follow-up to #121 (forgejo-helm `14.0.4` → `17.1.1`). #121 was **reverted** (commit `30acc03`) because Fleet reconciliation failed with:

```
execution error at (forgejo/templates/gitea/admin-secret.yaml:12:15):
PASSWORDS ERROR: You must provide your current passwords when upgrading the release.
...
'gitea.admin.password' must not be empty
```

This PR re-applies the `14.0.4` → `17.1.1` bump **together with** the change required to make it succeed.

## Cause

forgejo-helm **v15** changed how the admin user/password is managed ([README "To v15"](https://artifacthub.io/packages/helm/forgejo-helm/forgejo#to-v15)):

- The chart now ships `admin-secret.yaml`, which uses the Bitnami `common.secrets.passwords.manage` helper.
- On **upgrade**, this helper looks up the existing `<release>-admin` Secret. If it is absent **and** `gitea.admin.password` is unset, it **fails** with the error above.

In this repo the admin password has never been stored in a Helm Secret — the admin account was created at initial setup and the password reset out-of-band. So no `<release>-admin` Secret exists.

## Fix

- chart `14.0.4` → `17.1.1` (re-applies #121)
- `gitea.admin.username: ""` disables chart-side admin management. Verified with `helm template` (**v3.18 and v4.2**) that this removes the admin Secret, the `GITEA_ADMIN_*` env, and the `configure_admin_user` function — all three share the `if or existingSecret username` guard, so empty username disables them together. The existing `pikatenor` admin account in the DB (PVC) is **preserved**.

`passwordMode` removed: it only takes effect inside the username guard, so it is a no-op here.

## Note on the Fleet PR-check diff

The check renders base (`14.0.4`) vs head (`17.1.1`), so the admin env still appears on the **base** side and `GITEA_ADMIN_PASSWORD_MODE` shows as changing to `keepUpdated`. In the actual head render (`17.1.1` + `username: ""`) the env is fully removed, so `keepUpdated` never reaches the pod. (And even if it did, `configure_admin_user` — the only consumer — is under the same guard and is not rendered.)

## After merge

Confirm Fleet reconciles the release to `17.1.1` and the admin login still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)