### PR TITLE
Fix CI broken pipe when truncating large helm diffs.

### DIFF
--- a/.github/workflows/fleet-pr-checks.yml
+++ b/.github/workflows/fleet-pr-checks.yml
@@ -188,8 +188,9 @@ jobs:
                 continue
               fi
 
+              diff_file="$tmp_root/out/diff-${safe_name}.txt"
               set +e
-              diff_output="$(diff -u "$base_out" "$head_out" 2>&1)"
+              diff -u "$base_out" "$head_out" > "$diff_file" 2>&1
               diff_code=$?
               set -e
 
@@ -198,7 +199,7 @@ jobs:
               elif [[ $diff_code -eq 1 ]]; then
                 echo "Rendered manifest changes detected." >> "$fleet_summary_file"
                 echo '```diff' >> "$fleet_summary_file"
-                printf "%s\n" "$diff_output" | head -c 16000 >> "$fleet_summary_file"
+                head -c 16000 "$diff_file" >> "$fleet_summary_file"
                 echo >> "$fleet_summary_file"
                 echo '```' >> "$fleet_summary_file"
               else
@@ -247,19 +248,23 @@ jobs:
               continue
             fi
 
+            diff_file="$tmp_root/out/diff-${safe_name}.txt"
             set +e
-            diff_output="$(diff -u "$base_out" "$head_out" 2>&1)"
+            diff -u "$base_out" "$head_out" > "$diff_file" 2>&1
             diff_code=$?
             set -e
 
             if [[ $diff_code -eq 0 ]]; then
               echo "No rendered bundle changes." >> "$fleet_summary_file"
-            else
+            elif [[ $diff_code -eq 1 ]]; then
               echo "Rendered bundle changes detected." >> "$fleet_summary_file"
               echo '```diff' >> "$fleet_summary_file"
-              printf "%s\n" "$diff_output" | head -c 16000 >> "$fleet_summary_file"
+              head -c 16000 "$diff_file" >> "$fleet_summary_file"
               echo >> "$fleet_summary_file"
               echo '```' >> "$fleet_summary_file"
+            else
+              had_error="true"
+              echo "diff failed (exit ${diff_code})." >> "$fleet_summary_file"
             fi
 
             echo >> "$fleet_summary_file"
@@ -328,6 +333,9 @@ jobs:
             echo "### Cluster diff (kubediff)"
           } > "$summary_file"
 
+          tmp_root="$(mktemp -d)"
+          trap 'rm -rf "$tmp_root"' EXIT
+
           had_error="false"
           while IFS= read -r file; do
             echo "#### ${file}" >> "$summary_file"
@@ -338,8 +346,9 @@ jobs:
               continue
             fi
 
+            diff_file="$tmp_root/$(basename "$file").diff"
             set +e
-            diff_output="$(kubediff --skip-secrets -f "$file" 2>&1)"
+            kubediff --skip-secrets -f "$file" > "$diff_file" 2>&1
             diff_code=$?
             set -e
 
@@ -352,9 +361,9 @@ jobs:
               had_error="true"
             fi
 
-            if [[ -n "$diff_output" ]]; then
+            if [[ -s "$diff_file" ]]; then
               echo '```diff' >> "$summary_file"
-              printf "%s\n" "$diff_output" | head -c 12000 >> "$summary_file"
+              head -c 12000 "$diff_file" >> "$summary_file"
               echo >> "$summary_file"
               echo '```' >> "$summary_file"
             fi
@@ -386,6 +395,10 @@ jobs:
           changed_file="changed-files-${{ matrix.cluster }}.txt"
           summary_file="pr-check-summary-${{ matrix.cluster }}.md"
 
+          git_diff_file="$(mktemp)"
+          trap 'rm -f "$git_diff_file"' EXIT
+          xargs -r git diff --unified=3 "$base_sha" "$head_sha" -- < "$changed_file" > "$git_diff_file" || true
+
           {
             echo "## Fleet PR Checks (${{ matrix.cluster }})"
             echo
@@ -396,7 +409,7 @@ jobs:
             echo
             echo "### Git diff"
             echo '```diff'
-            xargs -r git diff --unified=3 "$base_sha" "$head_sha" -- < "$changed_file" | head -c 60000
+            head -c 60000 "$git_diff_file"
             echo
             echo '```'
             echo


### PR DESCRIPTION
Write diff output to temp files before head -c so pipefail does not fail on SIGPIPE.