### PR TITLE
fix mstream healthcheck path

### DIFF
--- a/borg4/default/mstream.yml
+++ b/borg4/default/mstream.yml
@@ -32,7 +32,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /
+            path: /api/v1/jukebox/get-now-playing
             port: 3000
             scheme: HTTP
           initialDelaySeconds: 10


### PR DESCRIPTION
fixup #125.

mStream v6 no longer returns 2xx for root path.
use another anonymous API instead.