### PR TITLE
remove deprecated traefik-crds chart

### DIFF
--- a/starlight30/traefik-crds/fleet.yaml
+++ b/starlight30/traefik-crds/fleet.yaml
@@ -1,7 +1,0 @@
-labels:
-  app: traefik-crds
-
-helm:
-  repo: https://traefik.github.io/charts
-  chart: traefik-crds
-  version: 1.18.0


### PR DESCRIPTION
fixup #140 

deprecated になって手動管理が推奨されてるようなので削除します