### PR TITLE
remove removed bundle

### DIFF
--- a/starlight30/traefik/fleet.yaml
+++ b/starlight30/traefik/fleet.yaml
@@ -35,7 +35,4 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        app: traefik-crds
-  - selector:
-      matchLabels:
         app: cert-manager


### PR DESCRIPTION
fixup #145 
```
list bundledeployments: no bundles matching labels app=traefik-crds in namespace fleet-default
```