### PR TITLE
fix(borg4): pin all pods to node juno4a

### DIFF
--- a/borg4/default/ado.yml
+++ b/borg4/default/ado.yml
@@ -43,6 +43,7 @@ spec:
             successThreshold: 2
             timeoutSeconds: 2
           resources: {}
+      nodeName: juno4a
       imagePullSecrets:
         - name: p1kachu
         - name: c.p1kachu.net

--- a/borg4/default/lavamusic.yml
+++ b/borg4/default/lavamusic.yml
@@ -66,6 +66,7 @@ spec:
               mountPath: /db
         #- name: locales
         #  mountPath: /opt/lavamusic/locales
+      nodeName: juno4a
       imagePullSecrets:
         - name: c.p1kachu.net
       volumes:

--- a/borg4/default/mumbot.yml
+++ b/borg4/default/mumbot.yml
@@ -26,5 +26,6 @@ spec:
         imagePullPolicy: Always
         name: mumbot
         resources: {}
+      nodeName: juno4a
       imagePullSecrets:
       - name: p1kachu

--- a/borg4/default/piping.yml
+++ b/borg4/default/piping.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         workload.user.cattle.io/workloadselector: deployment-default-piping
     spec:
+      nodeName: juno4a
       containers:
       - image: nwtgck/piping-server:v1.12.9@sha256:2b8452c93e5bc6dd7b1f1bfcb5df85bf973a8b167082823a4b986bfb930a7c1a
         imagePullPolicy: Always

--- a/borg4/default/speedtest.yml
+++ b/borg4/default/speedtest.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         workload.user.cattle.io/workloadselector: deployment-default-speedtest
     spec:
+      nodeName: juno4a
       containers:
       - env:
         - name: MODE

--- a/borg4/default/whoami.yml
+++ b/borg4/default/whoami.yml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: whoami
     spec:
+      nodeName: juno4a
       containers:
         - name: whoami
           image: traefik/whoami:v1.11.0@sha256:200689790a0a0ea48ca45992e0450bc26ccab5307375b41c84dfc4f2475937ab


### PR DESCRIPTION
Add nodeName: juno4a to deployments that were missing it (ado, piping,
speedtest, lavamusic, mumbot, whoami) to match the other workloads.