### PR TITLE
Add litellm proxy to borg4

### DIFF
--- a/.github/workflows/fleet-pr-checks.yml
+++ b/.github/workflows/fleet-pr-checks.yml
@@ -158,9 +158,6 @@ jobs:
             mkdir -p "$tmp_root/base"
             mkdir -p "$tmp_root/out"
 
-            # A bundle added in this PR has no base revision. Detect that up
-            # front so we treat base as empty (the diff then shows the full
-            # addition) instead of erroring on a missing path.
             base_exists="true"
             if ! git cat-file -e "${base_sha}:${bundle_dir}" 2>/dev/null; then
               base_exists="false"

--- a/.github/workflows/fleet-pr-checks.yml
+++ b/.github/workflows/fleet-pr-checks.yml
@@ -114,6 +114,17 @@ jobs:
           changed_file="changed-files-${{ matrix.cluster }}.txt"
           fleet_summary_file="fleet-bundle-summary-${{ matrix.cluster }}.md"
 
+          # `fleet apply` (used below to render raw bundles) needs a kubeconfig
+          # to resolve targets even with `-o -`. Decode the CI kubeconfig up
+          # front so raw bundles render like helm bundles.
+          ci_kubeconfig=""
+          if [[ -n "${KUBECONFIG_B64:-}" ]]; then
+            ci_kubeconfig="$(mktemp)"
+            printf '%s' "$KUBECONFIG_B64" | base64 -d > "$ci_kubeconfig"
+            chmod 600 "$ci_kubeconfig"
+            export KUBECONFIG="$ci_kubeconfig"
+          fi
+
           is_helm_only_bundle() {
             local dir="$1"
             local other_count
@@ -147,22 +158,38 @@ jobs:
             mkdir -p "$tmp_root/base"
             mkdir -p "$tmp_root/out"
 
+            # A bundle added in this PR has no base revision. Detect that up
+            # front so we treat base as empty (the diff then shows the full
+            # addition) instead of erroring on a missing path.
+            base_exists="true"
+            if ! git cat-file -e "${base_sha}:${bundle_dir}" 2>/dev/null; then
+              base_exists="false"
+            fi
+
+            base_out="$tmp_root/out/base-${safe_name}.yaml"
+            head_out="$tmp_root/out/head-${safe_name}.yaml"
+            [[ "$base_exists" == "true" ]] || : > "$base_out"
+
             if is_helm_only_bundle "$bundle_dir"; then
               echo "Helm-only bundle; rendering chart with helm template." >> "$fleet_summary_file"
 
-              if ! git archive "$base_sha" "$bundle_dir" | tar -x -C "$tmp_root/base"; then
-                echo "Failed to extract base revision for ${bundle_dir}." >> "$fleet_summary_file"
-                had_error="true"
-                echo >> "$fleet_summary_file"
-                continue
+              base_render_code=0
+              if [[ "$base_exists" == "true" ]]; then
+                if ! git archive "$base_sha" "$bundle_dir" | tar -x -C "$tmp_root/base"; then
+                  echo "Failed to extract base revision for ${bundle_dir}." >> "$fleet_summary_file"
+                  had_error="true"
+                  echo >> "$fleet_summary_file"
+                  continue
+                fi
+                set +e
+                ./scripts/fleet-helm-template.sh "$tmp_root/base/$bundle_dir" > "$base_out" 2>&1
+                base_render_code=$?
+                set -e
+              else
+                echo "New bundle in this PR (absent in base); showing full addition." >> "$fleet_summary_file"
               fi
 
-              base_out="$tmp_root/out/base-${safe_name}.yaml"
-              head_out="$tmp_root/out/head-${safe_name}.yaml"
-
               set +e
-              ./scripts/fleet-helm-template.sh "$tmp_root/base/$bundle_dir" > "$base_out" 2>&1
-              base_render_code=$?
               ./scripts/fleet-helm-template.sh "$bundle_dir" > "$head_out" 2>&1
               head_render_code=$?
               set -e
@@ -210,19 +237,23 @@ jobs:
               continue
             fi
 
-            if ! git archive "$base_sha" "$bundle_dir" | tar -x -C "$tmp_root/base"; then
-              echo "Failed to extract base revision for ${bundle_dir}." >> "$fleet_summary_file"
-              had_error="true"
-              echo >> "$fleet_summary_file"
-              continue
+            base_render_code=0
+            if [[ "$base_exists" == "true" ]]; then
+              if ! git archive "$base_sha" "$bundle_dir" | tar -x -C "$tmp_root/base"; then
+                echo "Failed to extract base revision for ${bundle_dir}." >> "$fleet_summary_file"
+                had_error="true"
+                echo >> "$fleet_summary_file"
+                continue
+              fi
+              set +e
+              fleet apply --driven-scan -o - "base-${safe_name}" "$tmp_root/base/$bundle_dir" > "$base_out" 2>&1
+              base_render_code=$?
+              set -e
+            else
+              echo "New bundle in this PR (absent in base); showing full addition." >> "$fleet_summary_file"
             fi
 
-            base_out="$tmp_root/out/base-${safe_name}.yaml"
-            head_out="$tmp_root/out/head-${safe_name}.yaml"
-
             set +e
-            fleet apply --driven-scan -o - "base-${safe_name}" "$tmp_root/base/$bundle_dir" > "$base_out" 2>&1
-            base_render_code=$?
             fleet apply --driven-scan -o - "head-${safe_name}" "$bundle_dir" > "$head_out" 2>&1
             head_render_code=$?
             set -e

--- a/borg4/litellm/fleet.yaml
+++ b/borg4/litellm/fleet.yaml
@@ -1,0 +1,41 @@
+defaultNamespace: litellm
+labels:
+  app: litellm
+
+helm:
+  chart: oci://ghcr.io/berriai/litellm-helm
+  version: 1.92.0
+  releaseName: litellm
+  values:
+    # Master key + provider API keys + DB credentials all live in the single
+    # out-of-band Secret `litellm` (borg4/litellm/resources/litellm.secret.yml).
+    masterkeySecretName: litellm
+    masterkeySecretKey: masterkey
+    environmentSecrets:
+      - litellm
+
+    db:
+      useExisting: true
+      deployStandalone: false
+      endpoint: litellm-psql
+      database: litellm
+      url: postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST)/$(DATABASE_NAME)
+      secret:
+        name: litellm
+        usernameKey: db-username
+        passwordKey: db-password
+
+    # Proxy config is authored as a separate ConfigMap in resources/config.yml
+    # so model/provider edits don't require re-rendering the Helm bundle.
+    proxyConfigMap:
+      create: false
+      name: litellm-config
+
+    service:
+      type: LoadBalancer
+      port: 4000
+
+dependsOn:
+  - selector:
+      matchLabels:
+        app: litellm-resources

--- a/borg4/litellm/resources/config.yml
+++ b/borg4/litellm/resources/config.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: litellm
+data:
+  config.yaml: |
+    # LiteLLM proxy config. API keys are sourced from the `litellm` Secret
+    # (environmentSecrets) via os.environ/<NAME>. Wildcard model_name entries
+    # route any model under that provider.
+    model_list:
+      - model_name: "anthropic/*"
+        litellm_params:
+          model: "anthropic/*"
+          api_key: os.environ/ANTHROPIC_API_KEY
+      - model_name: "openai/*"
+        litellm_params:
+          model: "openai/*"
+          api_key: os.environ/OPENAI_API_KEY
+      - model_name: "gemini/*"
+        litellm_params:
+          model: "gemini/*"
+          api_key: os.environ/GEMINI_API_KEY
+    general_settings:
+      master_key: os.environ/PROXY_MASTER_KEY

--- a/borg4/litellm/resources/fleet.yaml
+++ b/borg4/litellm/resources/fleet.yaml
@@ -1,0 +1,3 @@
+defaultNamespace: litellm
+labels:
+  app: litellm-resources

--- a/borg4/litellm/resources/postgres.yml
+++ b/borg4/litellm/resources/postgres.yml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    workload.user.cattle.io/workloadselector: deployment-litellm-litellm-psql
+  name: litellm-psql
+  namespace: litellm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      workload.user.cattle.io/workloadselector: deployment-litellm-litellm-psql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        workload.user.cattle.io/workloadselector: deployment-litellm-litellm-psql
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 1001
+      containers:
+        - name: postgres
+          image: "mirror.gcr.io/bitnami/postgresql:16-debian-12@sha256:233f361c5819c180b600d110d7da953bea6f1a00764752643ffb7b78ba85c628"
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/var/lib/postgresql"
+            - name: PGDATA
+              value: "/var/lib/postgresql/data"
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            - name: POSTGRES_USER
+              value: "litellm"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: litellm
+                  key: db-password
+            - name: POSTGRESQL_DATABASE
+              value: "litellm"
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            privileged: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 20m
+              memory: 64Mi
+          ports:
+            - containerPort: 5432
+              name: postgres
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "$POSTGRES_USER" -h 127.0.0.1 -p 5432
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "$POSTGRES_USER" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /var/lib/postgresql/.initialized ]
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: vrun
+              mountPath: /var/run/postgresql
+            - name: tmp
+              mountPath: /tmp
+            - name: litellm-psql-storage
+              mountPath: /var/lib/postgresql
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 256Mi
+        - name: vrun
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: litellm-psql-storage
+          hostPath:
+            path: /media/Hayate/litellm-psql
+            type: Directory
+      nodeName: juno4a
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm-psql
+  namespace: litellm
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+      protocol: TCP
+      targetPort: postgres
+  selector:
+    workload.user.cattle.io/workloadselector: deployment-litellm-litellm-psql
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
## What

Deploy the [LiteLLM](https://docs.litellm.ai/docs/proxy/quick_start) proxy (OpenAI-compatible gateway to Anthropic / OpenAI / Gemini) to borg4. This is the first Helm-type Fleet bundle under `borg4/`, following the `starlight30/cert-manager` pattern (helm-only `fleet.yaml` + nested `resources/` raw bundle).

## Layout

```
borg4/litellm/
  fleet.yaml                      # helm bundle: oci://ghcr.io/berriai/litellm-helm 1.92.0
  resources/
    fleet.yaml                    # raw bundle (defaultNamespace: litellm, label app: litellm-resources)
    config.yml                    # proxy config.yaml as a standalone ConfigMap (litellm-config)
    postgres.yml                  # self-managed postgres Deployment + ClusterIP Service (litellm-psql)
    litellm.secret.yml            # GITIGNORED — master key, DB creds, provider API keys (applied out-of-band)
```

## Design choices

- **Chart**: `oci://ghcr.io/berriai/litellm-helm` **1.92.0** (appVersion 1.92.0). Rendered via `scripts/fleet-helm-template.sh`, which already supports `oci://` charts.
- **Postgres**: self-managed, bounca-style (`mirror.gcr.io/bitnami/postgresql:16-debian-12` digest-pinned, hostPath `/media/Hayate/litellm-psql`, `nodeName: juno4a`), wired via `db.useExisting`. Avoids the bundled Bitnami subchart (versioned-image distribution issues; Renovate already disables updates for `mirror.gcr.io/bitnami/postgresql`) and keeps the DB on the HDD array.
- **Proxy config** is a separate ConfigMap (`config.yml`) rather than inline `proxy_config` values, so model/provider edits don't require re-rendering the Helm bundle. The chart mounts it via `proxyConfigMap.create: false` + `name: litellm-config`.
  - ⚠️ Because the chart's `checksum/config` annotation only covers chart-created ConfigMaps, editing `config.yml` will **not** roll the proxy automatically — run `kubectl --context borg-dii rollout restart -n litellm deployment/litellm` after a config change.
- **Secrets**: no SOPS. Single out-of-band Secret `litellm` (gitignored) holds the master key (`masterkey`), DB creds (`db-username`/`db-password`), and provider keys (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/`GEMINI_API_KEY`). The chart reads `PROXY_MASTER_KEY` + DB creds via `secretKeyRef` and pulls in the provider keys via `environmentSecrets` (`envFrom`), so `os.environ/<NAME>` references in `config.yml` resolve.
- **Exposure**: chart Service is `type: LoadBalancer` on port 4000 → MetalLB assigns a `192.168.21.x` IP; CoreDNS `k8s_external` gives a `*.borg.dii` name. No ingress/TLS on borg4 (consistent with other borg4 workloads).
- **Ordering**: the helm bundle `dependsOn` the `litellm-resources` bundle so Fleet installs postgres + the ConfigMap before the chart's Prisma `migrationJob` runs.

## Out-of-band steps (before/at merge)

1. On juno4a: `sudo mkdir -p /media/Hayate/litellm-psql && sudo chown 1001 /media/Hayate/litellm-psql` (postgres runs as uid 1001; `hostPath.type: Directory` requires the dir to pre-exist, same as bounca).
2. Fill real values into `borg4/litellm/resources/litellm.secret.yml`, then:
   ```bash
   kubectl --context borg-dii create namespace litellm
   kubectl --context borg-dii apply -f borg4/litellm/resources/litellm.secret.yml
   ```
   Apply the secret **before merge** so the first Fleet sync can start the pods.

## Verification done locally

- `.venv/bin/yamllint borg4/litellm/` → clean.
- `scripts/fleet-helm-template.sh` equivalent render (chart 1.92.0) → produces Deployment, migration Job, Pod(s), LoadBalancer Service; subcharts (postgresql/redis) correctly absent. Rendered Deployment confirms:
  - `DATABASE_URL = postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST)/$(DATABASE_NAME)` (K8s var interpolation)
  - `PROXY_MASTER_KEY` ← secret `litellm` key `masterkey`; DB creds ← keys `db-username`/`db-password`; provider keys via `envFrom`
  - ConfigMap `litellm-config` mounted at `/etc/litellm/config.yaml`
  - Service `type: LoadBalancer`, port 4000

## Post-merge checks

- `fleet-post-merge-checks` green (GitRepo `status.commit` + `Ready` converge to the pushed SHA).
- `kubectl --context borg-dii get pods -n litellm` → migration Job `Completed`, proxy + postgres `Running`.
- `kubectl --context borg-dii get svc -n litellm litellm` → MetalLB-assigned IP.
- `curl http://<LB-IP>:4000/health/liveliness` → alive; `curl -H "Authorization: Bearer <masterkey>" http://<LB-IP>:4000/v1/models` lists the three wildcard entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)