### PR TITLE
Fix litellm postgres CrashLoopBackOff: drop runAsGroup

### DIFF
--- a/borg4/litellm/resources/postgres.yml
+++ b/borg4/litellm/resources/postgres.yml
@@ -43,7 +43,6 @@ spec:
               value: "litellm"
           securityContext:
             runAsUser: 1001
-            runAsGroup: 1001
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false


### PR DESCRIPTION
## What

Fixes the `litellm-psql` pod CrashLoopBackOff on borg4.

## Root cause

The bitnami postgresql container runs as `uid=1001` with **primary gid=0 (root)** by image default, and `/opt/bitnami/postgresql/conf` (in the image rootfs) is owned `0:0` with group-write (`drwxrwxr-x`). On first DB init the entrypoint writes `pg_hba.conf` / `postgresql.conf` there, relying on the process being in **group 0**.

The manifest set `securityContext.runAsGroup: 1001`, which overrides the default and drops the process out of group 0 → loses group-write on the `0:0` conf dir:

```
postgresql 01:28:04.35 INFO ==> pg_hba.conf file not detected. Generating it...
/opt/bitnami/scripts/libpostgresql.sh: line 234: /opt/bitnami/postgresql/conf/pg_hba.conf: Permission denied
/opt/bitnami/scripts/libfile.sh: line 41: /opt/bitnami/postgresql/conf/postgresql.conf: Permission denied
```

`bounca`'s postgres (same image, working) does **not** set `runAsGroup` — it inherits gid=0, so it can write the conf dir. Bounca never hit this only because its data dir was already initialized (it skips config generation).

## Fix

Remove `runAsGroup: 1001` from the postgres container `securityContext`, matching bounca. The process keeps primary gid=0 (can write the image's `0:0` conf dir), while `podSecurityContext.fsGroup: 1001` still grants access to the hostPath data volume via a supplementary group — same configuration that works for bounca.

## Verify

After merge (Fleet re-syncs), on borg4:
```
kubectl --context borg-dii -n litellm logs -l app=litellm-resources --container postgres  # should show init + "PostgreSQL is fully started"
kubectl --context borg-dii -n litellm get pods -n litellm                                  # litellm-psql Running
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)